### PR TITLE
Fixes checking of arguments originating as pointers

### DIFF
--- a/outparamcheck/outparamcheck.go
+++ b/outparamcheck/outparamcheck.go
@@ -208,7 +208,13 @@ func isAddr(expr ast.Expr) bool {
 		child, ok := expr.X.(*ast.UnaryExpr)
 		return ok && child.Op == token.AND
 	case *ast.Ident:
-		// Allow passing literal nil
+		if expr.Obj != nil && expr.Obj.Decl != nil {
+			switch child := expr.Obj.Decl.(type) {
+			case *ast.AssignStmt:
+				return isAddr(child.Rhs[0])
+			}
+		}
+		// Allow passing a pointer or literal nil
 		return expr.Name == "nil"
 	default:
 		return false


### PR DESCRIPTION
Former version of the check ignored cases, when variables passed in
as argument to a function call was taken as a pointer/address to a
struct based definition. Updated test case is failing without the code
change.

Originally reported in https://github.com/palantir/godel/issues/226 and fixing it.